### PR TITLE
Fixes src/fib.ts#L11 errors: n type and return type

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,12 +1,11 @@
 // util function that computes the fibonacci numbers
 export function fibonacci(n: number): number | undefined {
   if (n < 0) {
-    return -1;
-  } else if (n == 0) {
+    return undefined;
+  } else if (n === 0) {
     return 0;
-  } else if (n == 1) {
+  } else if (n === 1) {
     return 1;
   }
-
   return fibonacci(n - 1) + fibonacci(n - 2);
 }

--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export function fibonacci(n: number): number | undefined {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
The variable n was of type any and the returned type was also any. However the fibRoute.ts was accepting undefined or other variable type.

So by giving the variable n a type, it fixed 3 issues relevant to test: src/fib.ts#L11..