### PR TITLE
Fixes src/fib.ts#L11 errors: n type and return type

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,12 +1,11 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export function fibonacci(n: number): number | undefined {
   if (n < 0) {
-    return -1;
-  } else if (n == 0) {
+    return undefined;
+  } else if (n === 0) {
     return 0;
-  } else if (n == 1) {
+  } else if (n === 1) {
     return 1;
   }
-
   return fibonacci(n - 1) + fibonacci(n - 2);
 }


### PR DESCRIPTION
The type of n is any and the function also returns any, which is making the issue.

Fixes the 3 issues of test: src/fib.ts#L11.